### PR TITLE
feat(platform): WCSS-5478 Override SeomaticService

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+# Why Override SEOmatic?
+Canada (`bigcommerce.ca`) serves the same content as the US (`bigcommerce.com`). Craft can correctly serve and cache _true_ locales, but Canada's `en_ca` is not a _true_ locale, it serves `en_us` content. However, some SEO/links are different, so it needs it's own cache. htmlcache(Redis) uses `CACHE_KEY`. This created a problem when hitting `.ca` then `.com` (or `.com` then `.ca`). SEOmatic's canonical URL would set correctly for the _first_ hit address, and cache accordingly. However, hitting the _second_ address would serve the cached SEOmatic metadata from the _first_ (including the canonical URL). In order to consistently and correctly get and serve CA and US SEOmatic data, we need to include Craft's `CACHE_KEY` from the Craft server.
+
+# DEPRECATED
+
+This Craft CMS 2.x plugin is no longer supported, but it is fully functional, and you may continue to use it as you see fit. The license also allows you to fork it and make changes as needed for legacy support reasons.
+
+The Craft CMS 3.x version of this plugin can be found here: [craft-seomatic](https://github.com/nystudio107/craft-seomatic) and can also be installed via the Craft Plugin Store in the Craft CP.
+
 # SEOmatic plugin for Craft
 
 A turnkey SEO implementation for Craft CMS that is comprehensive, powerful, and flexible.

--- a/SeomaticPlugin.php
+++ b/SeomaticPlugin.php
@@ -26,7 +26,7 @@ class SeomaticPlugin extends BasePlugin
 
     public function getVersion()
     {
-        return '1.1.56';
+        return '1.1.57';
     }
 
     public function getSchemaVersion()

--- a/services/SeomaticService.php
+++ b/services/SeomaticService.php
@@ -24,6 +24,10 @@ class SeomaticService extends BaseApplicationComponent
     protected $cachedWebSiteJSONLD = array();
     protected $renderedMetaVars = null;
 
+    public function getCashKey() {
+        return CACHE_KEY;
+    }
+
 /* --------------------------------------------------------------------------------
     Render the all of the SEO Meta, caching it if possible
 -------------------------------------------------------------------------------- */
@@ -41,11 +45,15 @@ class SeomaticService extends BaseApplicationComponent
 /* -- Cache the results for speediness; 1 query to rule them all */
 
         $shouldCache = ($metaVars != null);
+        
         if (craft()->config->get('devMode'))
             $shouldCache = false;
         if ($shouldCache)
         {
-            $cacheKey = 'seomatic_metacache_' . $this->getMetaHashStr($templatePath, $metaVars);
+            /* -- Must include Craft's CACHE_KEY to correctly serve CA vs. US seomatic data. */
+            /* -- See README for details */
+            $craftCacheKey = $this->getCashKey();
+            $cacheKey = 'seomatic_metacache_' . $craftCacheKey . $this->getMetaHashStr($templatePath, $metaVars);
             $cache = craft()->cache->get($cacheKey);
             if ($cache)
                 return $cache;

--- a/services/SeomaticService.php
+++ b/services/SeomaticService.php
@@ -41,14 +41,15 @@ class SeomaticService extends BaseApplicationComponent
 /* -- Cache the results for speediness; 1 query to rule them all */
 
         $shouldCache = ($metaVars != null);
+        // SHANNON
         if (craft()->config->get('devMode'))
             $shouldCache = false;
         if ($shouldCache)
         {
             $cacheKey = 'seomatic_metacache_' . $this->getMetaHashStr($templatePath, $metaVars);
             $cache = craft()->cache->get($cacheKey);
-            if ($cache)
-                return $cache;
+            // if ($cache)
+            //     return $cache;
         }
 
 /* -- If Minify is installed, minify all the things */


### PR DESCRIPTION
## What Was Worked On
[WCSS-5478](https://jira.bigcommerce.com/browse/WCSS-5478)
#### Why?/What Was Wrong?


#### How this fixed it
Override SeomaticService to set with Craft `CACHE_KEY`.

## How To Test
1. Pull down branch and run `composer install`
2. Pull down [branch from craft](https://github.com/bigcommerce-labs/bc-craft/pull/2863), 
3. Update `"nystudio107/seomatic": "dev-WCSS-5478"` in `composer.json` and run composer install, then start the server.

## Screenshots


ping @bigcommerce-labs/wcss-platform
